### PR TITLE
bugfix: connect to unix socket without opts table

### DIFF
--- a/lib/resty/redis.lua
+++ b/lib/resty/redis.lua
@@ -140,9 +140,13 @@ function _M.connect(self, host, port_or_opts, opts)
     local ok, err
 
     if unix then
-        ok, err = sock:connect(host, port_or_opts)
-        opts = port_or_opts
-
+         -- second argument of sock:connect() cannot be nil
+         if port_or_opts ~= nil then
+             ok, err = sock:connect(host, port_or_opts)
+             opts = port_or_opts
+         else
+             ok, err = sock:connect(host)
+         end
     else
         ok, err = sock:connect(host, port_or_opts, opts)
     end


### PR DESCRIPTION
The second argument of `sock:connect()` cannot be `nil`.
Fixes #187
Bug introduced by 79d24214095c921b879319e512b2f20fddf0795e